### PR TITLE
chore(travis-CI): add node v8 to CI and remove v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-- '4'
 - '6'
+- '8'
 script:
 - npm run coverage
 - npm run codecov

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "validate-commit-msg": "^2.8.0"
   },
   "engines": {
-    "node": ">= 4.5.0"
+    "node": ">= 6.0.0"
   },
   "nyc": {
     "include": [


### PR DESCRIPTION
#### Summary
Add node v8 to CI and remove v4

#### Description

- Add of node v8 to CI and remove v4 in csv-parser-order

- Change of engine from node ">= 4.5.0" to ">= 6.0.0" in package.json

Part of [this issue](https://github.com/commercetools/nodejs-tasks-board/issues/10)